### PR TITLE
add config file

### DIFF
--- a/radiance_folder/model/aperture_group/README.md
+++ b/radiance_folder/model/aperture_group/README.md
@@ -30,7 +30,7 @@ states. Below is the content of `states.json` file:
 {
   "south_window": [
     {
-      "name": "0_clear",
+      "identifier": "0_clear",
       "default": "./south_window..default..000.rad",
       "direct": "./south_window..direct..000.rad",
       "black": "./south_window..black.rad",
@@ -39,7 +39,7 @@ states. Below is the content of `states.json` file:
       "dmtx": "./south_window..mtx.rad"
     },
     {
-      "name": "1_diffuse",
+      "identifier": "1_diffuse",
       "default": "./south_window..default..001.rad",
       "direct": "./south_window..direct..001.rad",
       "black": "./south_window..black.rad",
@@ -64,7 +64,7 @@ model above, the following needs to be added to the `states.json` file:
   ...
   "skylight": [
     {
-      "name": "0_diffuse",
+      "identifier": "0_diffuse",
       "default": "skylight..default..000.rad",
       "direct": "skylight..direct..000.rad",
       "black": "skylight..black..000.rad",
@@ -79,10 +79,10 @@ model above, the following needs to be added to the `states.json` file:
 ## Naming convention
 
 It is recommended that the `.rad` files be named with a standard convention as follows:
-`{aperture name}..{field name}..{state count}.rad`. For instance, 
+`{aperture identifier}..{field name}..{state count}.rad`. For instance, 
 `skylight..direct..000.rad` is the direct representation of skylight for state 0.
 
-Note that the `"name"` key in the JSONs is only used to provide a human-readable name
-for the state and it is not required. However, if it is provided, it is recommended
-that it start with an integer index for the state (eg. `0`, `1`, etc.) in order to
-make its position in the order of the states clearer.
+Note that the `"identifier"` key in the JSONs is only used to provide a human-readable
+identifier for the state. It is recommended that it start with an integer index for the
+state (eg. `0`, `1`, etc.) in order to make its position in the order of the states
+clearer.

--- a/radiance_folder/model/aperture_group/README.md
+++ b/radiance_folder/model/aperture_group/README.md
@@ -82,7 +82,6 @@ It is recommended that the `.rad` files be named with a standard convention as f
 `{aperture identifier}..{field name}..{state count}.rad`. For instance, 
 `skylight..direct..000.rad` is the direct representation of skylight for state 0.
 
-Note that the `"identifier"` key in the JSONs is only used to provide a human-readable
-identifier for the state. It is recommended that it start with an integer index for the
-state (eg. `0`, `1`, etc.) in order to make its position in the order of the states
-clearer.
+It is recommended that the `"identifier"` key in the JSONs starts with an integer index
+for the state (eg. `0`, `1`, etc.) in order to make its position in the order of the
+states clearer.

--- a/radiance_folder/model/aperture_group/states.json
+++ b/radiance_folder/model/aperture_group/states.json
@@ -1,7 +1,7 @@
 {
   "south_window": [
     {
-      "name": "0_clear",
+      "identifier": "0_clear",
       "default": "./south_window..default..000.rad",
       "direct": "./south_window..direct..000.rad",
       "black": "./south_window..black.rad",
@@ -10,7 +10,7 @@
       "dmtx": "./south_window..mtx.rad"
     },
     {
-      "name": "1_diffuse",
+      "identifier": "1_diffuse",
       "default": "./south_window..default..001.rad",
       "direct": "./south_window..direct..001.rad",
       "black": "./south_window..black.rad",

--- a/radiance_folder/model/folder.cfg
+++ b/radiance_folder/model/folder.cfg
@@ -1,0 +1,49 @@
+[GLOBAL]
+root = model  # folder name for the root folder
+static_apertures = static_apertures  # aperture group name for static apertures
+
+[APERTURE]
+path = aperture
+geo_pattern = ^.*\.rad$
+mod_pattern = ^.*\.mat$
+blk_pattern = ^.*\.blk$
+
+[APERTURE-GROUP]
+path = aperture_group
+states = states.json
+
+[INTERIOR-APERTURE-GROUP]
+path = aperture_group/interior 
+states = states.json
+
+[BSDF]
+path = bsdf
+bsdf_pattern = ^.*\.xml$
+
+[GRID]
+path = grid
+grid_pattern = ^.*\.pts$
+info_pattern = ^.*\.json$
+
+[IES]
+path = ies
+ies_pattern = ^.*\.ies$
+
+[SCENE]
+path = scene
+geo_pattern = ^.*\.rad$
+mod_pattern = ^.*\.mat$
+blk_pattern = ^.*\.blk$
+
+[DYNAMIC-SCENE]
+path = scene_dynamic
+states = states.json
+
+[INDOOR-DYNAMIC-SCENE]
+path = scene_dynamic/indoor
+states = states.json
+
+[VIEW]
+path = view
+view_pattern = ^.*\.vf$
+info_pattern = ^.*\.json$

--- a/radiance_folder/model/grid/cubical.json
+++ b/radiance_folder/model/grid/cubical.json
@@ -1,6 +1,6 @@
 {
     "count": 131,
-    "aperture_groups": [
+    "light_path": [
         ["static_apertures"],
         ["south_window"] 
     ]

--- a/radiance_folder/model/grid/hallway.json
+++ b/radiance_folder/model/grid/hallway.json
@@ -1,6 +1,6 @@
 {
     "count": 40,
-    "aperture_groups": [
+    "light_path": [
         ["static_apertures"],
         ["south_window"] 
     ]

--- a/radiance_folder/model/scene_dynamic/README.md
+++ b/radiance_folder/model/scene_dynamic/README.md
@@ -20,12 +20,12 @@ modeled the ground with two different materials for winter versus summer like so
 {
   "ground": [
     {
-      "name": "0_grass_covered",
+      "identifier": "0_grass_covered",
       "default": "ground..summer..000.rad",
       "direct": "ground..direct..000.rad",
     },
     {
-      "name": "1_snow_covered",
+      "identifier": "1_snow_covered",
       "default": "ground..winter..001.rad",
       "direct": "ground..direct..000.rad"
     }
@@ -53,12 +53,12 @@ like this:
 {
   "outdoor_trees": [
     {
-      "name": "0_summer_condition",
+      "identifier": "0_summer_condition",
       "default": "trees..summer..000.rad",
       "direct": "trees..direct..000.rad",
     },
     {
-      "name": "1_winter_condition",
+      "identifier": "1_winter_condition",
       "default": "trees..winter..001.rad",
       "direct": "trees..direct..001.rad"
     }


### PR DESCRIPTION
This PR:

1. Changes the `name` key to `identifier` in aperture groups states JSON file.
2. Changes the `aperture_groups` key to `light_path` in sensor grid info JSON file.
3. Adds `folder.cfg` file which allows editing and adjusting file and folder names for folder structure. This will make mapping other folder structures to Radiance folder structure much easier.